### PR TITLE
add image_load_from_memory helper

### DIFF
--- a/libgpujpeg/gpujpeg_common.h
+++ b/libgpujpeg/gpujpeg_common.h
@@ -498,6 +498,17 @@ GPUJPEG_API int
 gpujpeg_image_load_from_file(const char* filename, uint8_t** image, int* image_size);
 
 /**
+ * Load RGB image from memory
+ *
+ * @param[in]     image_src   Image data buffer from memory
+ * @param[out]    image       Image data buffer allocated as CUDA host buffer
+ * @param[in]     image_size  Image data buffer size
+ * @return 0 if succeeds, otherwise nonzero
+ */
+GPUJPEG_API int
+gpujpeg_image_load_from_memory(const uint8_t*image_src , uint8_t** image, int image_size);
+
+/**
  * Save RGB image to file
  *
  * @param filaname  Image filename

--- a/src/gpujpeg_common.cpp
+++ b/src/gpujpeg_common.cpp
@@ -957,6 +957,20 @@ gpujpeg_image_load_from_file(const char* filename, uint8_t** image, int* image_s
 
 /** Documented at declaration */
 int
+gpujpeg_image_load_from_memory(const uint8_t*image_src , uint8_t** image, int image_size)
+{
+    uint8_t* data = NULL;
+    cudaMallocHost((void**)&data, image_size * sizeof(uint8_t));
+    gpujpeg_cuda_check_error("Initialize CUDA host buffer", return -1);
+    memcpy(data, image_src, image_size);
+
+    *image = data;
+
+    return 0;
+}
+
+/** Documented at declaration */
+int
 gpujpeg_image_save_to_file(const char* filename, uint8_t* image, int image_size)
 {
     FILE* file;


### PR DESCRIPTION
Hello,

I am recently working on GPU jpeg encoding and this library offered me some great tools to accomplish my goal.
With some sort of digging on the source code, I realized there is no helper method that load image already in the memory.  I would like to contribute my code to help encode raw data that already in the memory.
Notes that my method modified based on gpu_image_load_from_file, however, some of the parameters are not working exactly the same as load_from_file. But this should provide a similar way to load data into CUDA host buffer. I have tested this method on my own code and it works as I desired.
Please let me know if there is anything need to improve on this pull request, and I would like to hear your feedback.

Best,
Xuhui