### PR TITLE
Fix memcpy sizes in gpujpeg_table_huffman_*_init()

### DIFF
--- a/src/gpujpeg_table.c
+++ b/src/gpujpeg_table.c
@@ -308,21 +308,30 @@ gpujpeg_table_huffman_encoder_init(struct gpujpeg_table_huffman_encoder* table, 
 {
     assert(comp_type == GPUJPEG_COMPONENT_LUMINANCE || comp_type == GPUJPEG_COMPONENT_CHROMINANCE);
     assert(huff_type == GPUJPEG_HUFFMAN_DC || huff_type == GPUJPEG_HUFFMAN_AC);
+    _Static_assert(sizeof(table->bits) >= sizeof(gpujpeg_table_huffman_y_dc_bits), "table buffer too small");
+    _Static_assert(sizeof(table->huffval) >= sizeof(gpujpeg_table_huffman_y_dc_value), "table buffer too small");
+    _Static_assert(sizeof(table->bits) >= sizeof(gpujpeg_table_huffman_y_ac_bits), "table buffer too small");
+    _Static_assert(sizeof(table->huffval) >= sizeof(gpujpeg_table_huffman_y_ac_value), "table buffer too small");
+    _Static_assert(sizeof(table->bits) >= sizeof(gpujpeg_table_huffman_cbcr_dc_bits), "table buffer too small");
+    _Static_assert(sizeof(table->huffval) >= sizeof(gpujpeg_table_huffman_cbcr_dc_value), "table buffer too small");
+    _Static_assert(sizeof(table->bits) >= sizeof(gpujpeg_table_huffman_cbcr_ac_bits), "table buffer too small");
+    _Static_assert(sizeof(table->huffval) >= sizeof(gpujpeg_table_huffman_cbcr_ac_value), "table buffer too small");
+
     if ( comp_type == GPUJPEG_COMPONENT_LUMINANCE ) {
         if ( huff_type == GPUJPEG_HUFFMAN_DC ) {
-            memcpy(table->bits, gpujpeg_table_huffman_y_dc_bits, sizeof(table->bits));
-            memcpy(table->huffval, gpujpeg_table_huffman_y_dc_value, sizeof(table->huffval));
+            memcpy(table->bits, gpujpeg_table_huffman_y_dc_bits, sizeof(gpujpeg_table_huffman_y_dc_bits));
+            memcpy(table->huffval, gpujpeg_table_huffman_y_dc_value, sizeof(gpujpeg_table_huffman_y_dc_value));
         } else {
-            memcpy(table->bits, gpujpeg_table_huffman_y_ac_bits, sizeof(table->bits));
-            memcpy(table->huffval, gpujpeg_table_huffman_y_ac_value, sizeof(table->huffval));
+            memcpy(table->bits, gpujpeg_table_huffman_y_ac_bits, sizeof(gpujpeg_table_huffman_y_ac_bits));
+            memcpy(table->huffval, gpujpeg_table_huffman_y_ac_value, sizeof(gpujpeg_table_huffman_y_ac_value));
         }        
     } else if ( comp_type == GPUJPEG_COMPONENT_CHROMINANCE ) {
         if ( huff_type == GPUJPEG_HUFFMAN_DC ) {
-            memcpy(table->bits, gpujpeg_table_huffman_cbcr_dc_bits, sizeof(table->bits));
-            memcpy(table->huffval, gpujpeg_table_huffman_cbcr_dc_value, sizeof(table->huffval));
+            memcpy(table->bits, gpujpeg_table_huffman_cbcr_dc_bits, sizeof(gpujpeg_table_huffman_cbcr_dc_bits));
+            memcpy(table->huffval, gpujpeg_table_huffman_cbcr_dc_value, sizeof(gpujpeg_table_huffman_cbcr_dc_value));
         } else {
-            memcpy(table->bits, gpujpeg_table_huffman_cbcr_ac_bits, sizeof(table->bits));
-            memcpy(table->huffval, gpujpeg_table_huffman_cbcr_ac_value, sizeof(table->huffval));
+            memcpy(table->bits, gpujpeg_table_huffman_cbcr_ac_bits, sizeof(gpujpeg_table_huffman_cbcr_ac_bits));
+            memcpy(table->huffval, gpujpeg_table_huffman_cbcr_ac_value, sizeof(gpujpeg_table_huffman_cbcr_ac_value));
         }
     }
     gpujpeg_table_huffman_encoder_compute(table);
@@ -336,21 +345,30 @@ gpujpeg_table_huffman_decoder_init(struct gpujpeg_table_huffman_decoder* table, 
 {
     assert(comp_type == GPUJPEG_COMPONENT_LUMINANCE || comp_type == GPUJPEG_COMPONENT_CHROMINANCE);
     assert(huff_type == GPUJPEG_HUFFMAN_DC || huff_type == GPUJPEG_HUFFMAN_AC);
+    _Static_assert(sizeof(table->bits) >= sizeof(gpujpeg_table_huffman_y_dc_bits), "table buffer too small");
+    _Static_assert(sizeof(table->huffval) >= sizeof(gpujpeg_table_huffman_y_dc_value), "table buffer too small");
+    _Static_assert(sizeof(table->bits) >= sizeof(gpujpeg_table_huffman_y_ac_bits), "table buffer too small");
+    _Static_assert(sizeof(table->huffval) >= sizeof(gpujpeg_table_huffman_y_ac_value), "table buffer too small");
+    _Static_assert(sizeof(table->bits) >= sizeof(gpujpeg_table_huffman_cbcr_dc_bits), "table buffer too small");
+    _Static_assert(sizeof(table->huffval) >= sizeof(gpujpeg_table_huffman_cbcr_dc_value), "table buffer too small");
+    _Static_assert(sizeof(table->bits) >= sizeof(gpujpeg_table_huffman_cbcr_ac_bits), "table buffer too small");
+    _Static_assert(sizeof(table->huffval) >= sizeof(gpujpeg_table_huffman_cbcr_ac_value), "table buffer too small");
+
     if ( comp_type == GPUJPEG_COMPONENT_LUMINANCE ) {
         if ( huff_type == GPUJPEG_HUFFMAN_DC ) {
-            memcpy(table->bits, gpujpeg_table_huffman_y_dc_bits, sizeof(table->bits));
-            memcpy(table->huffval, gpujpeg_table_huffman_y_dc_value, sizeof(table->huffval));
+            memcpy(table->bits, gpujpeg_table_huffman_y_dc_bits, sizeof(gpujpeg_table_huffman_y_dc_bits));
+            memcpy(table->huffval, gpujpeg_table_huffman_y_dc_value, sizeof(gpujpeg_table_huffman_y_dc_value));
         } else {
-            memcpy(table->bits, gpujpeg_table_huffman_y_ac_bits, sizeof(table->bits));
-            memcpy(table->huffval, gpujpeg_table_huffman_y_ac_value, sizeof(table->huffval));
+            memcpy(table->bits, gpujpeg_table_huffman_y_ac_bits, sizeof(gpujpeg_table_huffman_y_ac_bits));
+            memcpy(table->huffval, gpujpeg_table_huffman_y_ac_value, sizeof(gpujpeg_table_huffman_y_ac_value));
         }        
     } else if ( comp_type == GPUJPEG_COMPONENT_CHROMINANCE ) {
         if ( huff_type == GPUJPEG_HUFFMAN_DC ) {
-            memcpy(table->bits, gpujpeg_table_huffman_cbcr_dc_bits, sizeof(table->bits));
-            memcpy(table->huffval, gpujpeg_table_huffman_cbcr_dc_value, sizeof(table->huffval));
+            memcpy(table->bits, gpujpeg_table_huffman_cbcr_dc_bits, sizeof(gpujpeg_table_huffman_cbcr_dc_bits));
+            memcpy(table->huffval, gpujpeg_table_huffman_cbcr_dc_value, sizeof(gpujpeg_table_huffman_cbcr_dc_value));
         } else {
-            memcpy(table->bits, gpujpeg_table_huffman_cbcr_ac_bits, sizeof(table->bits));
-            memcpy(table->huffval, gpujpeg_table_huffman_cbcr_ac_value, sizeof(table->huffval));
+            memcpy(table->bits, gpujpeg_table_huffman_cbcr_ac_bits, sizeof(gpujpeg_table_huffman_cbcr_ac_bits));
+            memcpy(table->huffval, gpujpeg_table_huffman_cbcr_ac_value, sizeof(gpujpeg_table_huffman_cbcr_ac_value));
         }
     }
     gpujpeg_table_huffman_decoder_compute(table);


### PR DESCRIPTION
I got the following compiler warnings in the current master branch:

```
In file included from /usr/include/string.h:495,
                 from /home/user/schwarzm/contrib/GPUJPEG/src/gpujpeg_util.h:37,
                 from /home/user/schwarzm/contrib/GPUJPEG/src/gpujpeg_table.c:32:
In function ‘memcpy’,
    inlined from ‘gpujpeg_table_huffman_encoder_init’ at /home/user/schwarzm/contrib/GPUJPEG/src/gpujpeg_table.c:314:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34:10: warning: ‘__builtin_memcpy’ reading 256 bytes from a region of size 12 [-Wstringop-overflow=]
   34 |   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘memcpy’,
    inlined from ‘gpujpeg_table_huffman_encoder_init’ at /home/user/schwarzm/contrib/GPUJPEG/src/gpujpeg_table.c:317:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34:10: warning: ‘__builtin_memcpy’ reading 256 bytes from a region of size 162 [-Wstringop-overflow=]
   34 |   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘memcpy’,
    inlined from ‘gpujpeg_table_huffman_encoder_init’ at /home/user/schwarzm/contrib/GPUJPEG/src/gpujpeg_table.c:322:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34:10: warning: ‘__builtin_memcpy’ reading 256 bytes from a region of size 12 [-Wstringop-overflow=]
   34 |   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘memcpy’,
    inlined from ‘gpujpeg_table_huffman_encoder_init’ at /home/user/schwarzm/contrib/GPUJPEG/src/gpujpeg_table.c:325:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34:10: warning: ‘__builtin_memcpy’ reading 256 bytes from a region of size 162 [-Wstringop-overflow=]
   34 |   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘memcpy’,
    inlined from ‘gpujpeg_table_huffman_decoder_init’ at /home/user/schwarzm/contrib/GPUJPEG/src/gpujpeg_table.c:342:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34:10: warning: ‘__builtin_memcpy’ reading 256 bytes from a region of size 12 [-Wstringop-overflow=]
   34 |   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘memcpy’,
    inlined from ‘gpujpeg_table_huffman_decoder_init’ at /home/user/schwarzm/contrib/GPUJPEG/src/gpujpeg_table.c:345:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34:10: warning: ‘__builtin_memcpy’ reading 256 bytes from a region of size 162 [-Wstringop-overflow=]
   34 |   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘memcpy’,
    inlined from ‘gpujpeg_table_huffman_decoder_init’ at /home/user/schwarzm/contrib/GPUJPEG/src/gpujpeg_table.c:350:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34:10: warning: ‘__builtin_memcpy’ reading 256 bytes from a region of size 12 [-Wstringop-overflow=]
   34 |   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘memcpy’,
    inlined from ‘gpujpeg_table_huffman_decoder_init’ at /home/user/schwarzm/contrib/GPUJPEG/src/gpujpeg_table.c:353:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34:10: warning: ‘__builtin_memcpy’ reading 256 bytes from a region of size 162 [-Wstringop-overflow=]
   34 |   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
      |
```

Fix that by using the smaller source buffer size.

Also adds asserts to check that the buffers are large enough.