### PR TITLE
Support padded image

### DIFF
--- a/libgpujpeg/gpujpeg_common.h
+++ b/libgpujpeg/gpujpeg_common.h
@@ -275,6 +275,8 @@ struct gpujpeg_image_parameters {
     enum gpujpeg_color_space color_space;
     /// Image data sampling factor
     enum gpujpeg_pixel_format pixel_format;
+    /// Number of bytes padded to each row
+    int width_padding;
 };
 
 /**

--- a/src/gpujpeg_common.c
+++ b/src/gpujpeg_common.c
@@ -343,6 +343,7 @@ gpujpeg_image_set_default_parameters(struct gpujpeg_image_parameters* param)
     param->height = 0;
     param->color_space = GPUJPEG_RGB;
     param->pixel_format = GPUJPEG_444_U8_P012;
+    param->width_padding = 0;
 }
 
 struct gpujpeg_image_parameters
@@ -362,7 +363,8 @@ gpujpeg_image_parameters_equals(const struct gpujpeg_image_parameters *p1 , cons
     return p1->width == p2->width &&
         p1->height == p2->height &&
         p1->color_space == p2->color_space &&
-        p1->pixel_format == p2->pixel_format;
+        p1->pixel_format == p2->pixel_format &&
+        p1->width_padding == p2->width_padding;
 }
 
 /* Documented at declaration */

--- a/src/main.c
+++ b/src/main.c
@@ -173,7 +173,7 @@ adjust_params(struct gpujpeg_parameters* param, struct gpujpeg_image_parameters*
               const char* out, bool encode, const struct options* opts)
 {
     // if possible, read properties from file
-    struct gpujpeg_image_parameters file_param_image = { 0, 0, GPUJPEG_NONE, GPUJPEG_PIXFMT_NONE };
+    struct gpujpeg_image_parameters file_param_image = { 0, 0, GPUJPEG_NONE, GPUJPEG_PIXFMT_NONE, 0 };
     const char *raw_file = encode ? in : out;
     gpujpeg_image_get_properties(raw_file, &file_param_image, encode);
     param_image->width = USE_IF_NOT_NULL_ELSE(param_image->width, file_param_image.width);


### PR DESCRIPTION
Fix #92.

```
⋊> mlinux@mlinux ⋊> ~/C/GPUJPEG on padded-image-no-copy ⨯ nvidia-smi        
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 555.42.06              Driver Version: 555.42.06      CUDA Version: 12.5     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 3090        Off |   00000000:01:00.0 Off |                  N/A |
| 30%   42C    P8             26W /  350W |     166MiB /  24576MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

⋊> mlinux@mlinux ⋊> ~/C/GPUJPEG on padded-image-no-copy ⨯ cmake --build build --config Release && build/Release/bench
ninja: no work to do.
imgs/CS050-10UC.bmp: 2448x2048x1=5013504

|               ns/op |                op/s |    err% |     total | With cudaDeviceScheduleAuto
|--------------------:|--------------------:|--------:|----------:|:----------------------------
|          180,550.29 |            5,538.62 |    0.1% |      1.21 | `memcpy-cpu`
|          199,901.25 |            5,002.47 |    0.1% |      1.21 | `memcpy-cuda`
|          205,769.80 |            4,859.80 |    0.0% |      1.21 | `memcpy-pinned2dev`
|          288,606.12 |            3,464.93 |    0.2% |      1.21 | `memcpy-host2dev`
|        1,401,691.73 |              713.42 |    0.6% |      1.20 | `encode-rgb-auto`
|        1,810,735.36 |              552.26 |    0.1% |      1.21 | `encode-bayer-auto`
|        1,352,212.82 |              739.53 |    0.1% |      1.21 | `encode-bayer-gpu`
|        1,348,569.47 |              741.53 |    0.1% |      1.20 | `encode-bayer-auto-no-copy`
|          889,077.42 |            1,124.76 |    0.0% |      1.18 | `encode-bayer-gpu-no-copy`

# Here I changed the benchmark code to use another image
⋊> mlinux@mlinux ⋊> ~/C/GPUJPEG on padded-image-no-copy ⨯ cmake --build build --config Release && build/Release/bench
[2/2] Linking CXX executable Release/bench
imgs/CS004-10UC.bmp: 720x540x1=388800

|               ns/op |                op/s |    err% |     total | With cudaDeviceScheduleAuto
|--------------------:|--------------------:|--------:|----------:|:----------------------------
|           14,849.73 |           67,341.30 |    0.4% |      1.19 | `memcpy-cpu`
|           17,394.60 |           57,489.11 |    0.2% |      1.21 | `memcpy-cuda`
|           19,981.12 |           50,047.24 |    0.1% |      1.20 | `memcpy-pinned2dev`
|           35,231.62 |           28,383.60 |    0.1% |      1.21 | `memcpy-host2dev`
|          191,293.48 |            5,227.57 |    0.1% |      1.21 | `encode-rgb-auto`
|          323,941.14 |            3,086.98 |    0.1% |      1.21 | `encode-bayer-auto`
|          303,927.52 |            3,290.26 |    0.1% |      1.21 | `encode-bayer-gpu`
|          214,771.86 |            4,656.10 |    0.0% |      1.21 | `encode-bayer-auto-no-copy`
|          196,037.60 |            5,101.06 |    0.1% |      1.21 | `encode-bayer-gpu-no-copy`
```

As rough benchmark shows, the `cudaMemcpy2D` call turns out to be really expensive, accounting for around a third of the latency.